### PR TITLE
Changes:

### DIFF
--- a/src/node/mobilityManager/VirtualMobilityManager.cc
+++ b/src/node/mobilityManager/VirtualMobilityManager.cc
@@ -116,8 +116,9 @@ void VirtualMobilityManager::parseDeployment() {
 			gridz = 0;
 		}
 		
-		nodeLocation.x = (gridi % gridx) * (xlen / (gridx - 1));
-		nodeLocation.y = ((int)floor(gridi / gridx) % gridy) * (ylen / (gridy - 1));
+		// Ugly ?: hack. IF there is only one row/column of sensors, division by 0 happens
+        nodeLocation.x = (gridi % gridx) * (xlen / (gridx==1?2:gridx - 1));
+		nodeLocation.y = ((int)floor(gridi / gridx) % gridy) * (ylen / (gridy==1?2:gridy - 1));
 		if (gridz > 0 && zlen > 0) {
 			nodeLocation.z = ((int)floor(gridi / (gridx * gridy)) % gridz) * (zlen / (gridz - 1));
 		} else {


### PR DESCRIPTION
o Bugfix/workaround: if deployment is 1xn or nx1, division by 0 happens. The fix sets
  the nominator to 1 in the formula if it would be 0.

 Changes to be committed:
	modified:   src/node/mobilityManager/VirtualMobilityManager.cc