### PR TITLE
Changes

### DIFF
--- a/Simulations/hdmrp_testbed/test_om.ini
+++ b/Simulations/hdmrp_testbed/test_om.ini
@@ -14,9 +14,9 @@
 
 include ../Parameters/Castalia.ini
 
-sim-time-limit = 1000s
+sim-time-limit = 1010s
 
-include ../Parameters/SensorDevice/Accelerometer.ini
+#include ../Parameters/SensorDevice/Accelerometer.ini
 
 SN.physicalProcessName = "WildFirePhysicalProcess"
 SN.physicalProcess[*].map_file = "bundle_small.bin"
@@ -25,26 +25,71 @@ SN.physicalProcess[*].ca_step_period = 2000
 SN.physicalProcess[*].ca_start_timer = 2000
 
 
-
-
+# ___         _ _     
+#| _ \__ _ __| (_)___ 
+#|   / _` / _` | / _ \
+#|_|_\__,_\__,_|_\___/
+#
 SN.node[*].Communication.Radio.RadioParametersFile = "../Parameters/Radio/CC2420.txt"
-#SN.node[*].Communication.Radio.TxOutputPower = "4dBm"
+SN.node[*].Communication.Radio.TxOutputPower = "0dBm"
 #SN.node[*].Communication.Radio.RadioParametersFile = "../Parameters/Radio/BANRadio.txt"
+SN.node[*].Communication.Radio.mode = "normal"
+SN.node[*].Communication.Radio.collisionModel = 0
+#SN.node[*].Communication.Radio.carrierSenseInterruptEnabled = true
 
-SN.node[*].Communication.MACProtocolName = "TMAC"
-SN.node[*].Communication.MAC.maxTxRetries = 10 
-SN.node[*].Communication.MAC.contentionPeriod = 20
+# __  __   _   ___ 
+#|  \/  | /_\ / __|
+#| |\/| |/ _ \ (__ 
+#|_|  |_/_/ \_\___|
+#
+include ../Parameters/MAC/CSMA.ini
 
+SN.node[*].Communication.MA.CtxAllPacketsInFreeChannel = false
+SN.node[*].Communication.MA.numTx = 2
+
+#include ../Parameters/MAC/SMAC.ini
+
+#SN.node[*].Communication.MACProtocolName = "Basic802154"
+#SN.node[*].Communication.MAC.phyDataRate = 250
+#SN.node[*].Communication.MAC.phyBitsPerSymbol = 2
+
+#SN.node[*].Communication.MAC.maxTxRetries = 4
+#SN.node[*].Communication.MAC.contentionPeriod = 20
+
+
+#   _             _ _         _   _          
+#  /_\  _ __ _ __| (_)__ __ _| |_(_)___ _ _  
+# / _ \| '_ \ '_ \ | / _/ _` |  _| / _ \ ' \ 
+#/_/ \_\ .__/ .__/_|_\__\__,_|\__|_\___/_||_|
+#      |_|  |_|                              
 SN.node[*].ApplicationName = "ForestFire"
 SN.node[0].Application.isSink = true
 SN.node[*].Application.reportDestination = "0"
 
-SN.node[0..2].Application.isMaster = true 
-SN.node[7..9].Application.isMaster = true 
-SN.node[14..16].Application.isMaster = true 
+#SN.node[0..2].Application.isMaster = true 
+#SN.node[7..9].Application.isMaster = true 
+#SN.node[14..16].Application.isMaster = true
 
+
+#__      ___         _              ___ _                       _ 
+#\ \    / (_)_ _ ___| |___ ______  / __| |_  __ _ _ _  _ _  ___| |
+# \ \/\/ /| | '_/ -_) / -_|_-<_-< | (__| ' \/ _` | ' \| ' \/ -_) |
+#  \_/\_/ |_|_| \___|_\___/__/__/  \___|_||_\__,_|_||_|_||_\___|_|
+#
+
+#Ideal channel
+SN.wirelessChannel.sigma = 0
+SN.wirelessChannel.bidirectionalSigma = 0
+SN.wirelessChannel.pathLossExponent = 2.0
+
+# ___          _   _           
+#| _ \___ _  _| |_(_)_ _  __ _ 
+#|   / _ \ || |  _| | ' \/ _` |
+#|_|_\___/\_,_|\__|_|_||_\__, |
+#                        |___/ 
 SN.node[*].Communication.RoutingProtocolName = "hdmrp"
 SN.node[*].Communication.Routing.t_rreq = 2000
+SN.node[*].Communication.Routing.min_rreq_rssi = -90
 
 
 # _____                
@@ -53,20 +98,21 @@ SN.node[*].Communication.Routing.t_rreq = 2000
 #  |_||_| \__,_\__\___|
 #
 SN.node[*].Communication.Routing.collectTraceInfo = true
-SN.node[*].Communication.MAC.collectTraceInfo = true
-SN.node[*].Communication.MAC.printStateTransitions = true
-
+#SN.node[*].Communication.MAC.collectTraceInfo = true
+#SN.node[*].Communication.MAC.printStateTransitions = true
+#SN.node[*].Communication.Radio.collectTraceInfo = true
+#SN.wirelessChannel.collectTraceInfo = true 
 
 SN.physicalProcess[*].collectTraceInfo = true
-SN.node[*].Application.collectTraceInfo = true
-#SN.node[*].SensorManager.collectTraceInfo = true
+#SN.node[*].Application.collectTraceInfo = true
+SN.node[*].SensorManager.collectTraceInfo = true
 #SN.node[*].ResourceManager.collectTraceInfo = true
 #SN.node[*].MobilityManager.collectTraceInfo = true
 
 SN.field_x = 180
 SN.field_y = 180
-SN.numNodes = 49
-SN.deployment = "[0..48]->7x7"
+SN.numNodes = 12
+SN.deployment = "[0..11]->6x6"
 
 #SN.deployment = "[0]->center;[1..6]->3x2"
 #SN.node[0].xCoor = 10

--- a/src/node/application/ForestFire/forest_fire.cc
+++ b/src/node/application/ForestFire/forest_fire.cc
@@ -34,7 +34,7 @@ void ForestFire::startup()
 	report_info_table.clear();
 
 	if (!isSink) {
-		setTimer(ForestFireTimers::REQUEST_SAMPLE, sampleInterval);
+		setTimer(ForestFireTimers::REQUEST_SAMPLE, sampleInterval+std::atof(selfAddress.c_str()));
 	}
 }
 

--- a/src/node/application/ForestFire/forest_fire.ned
+++ b/src/node/application/ForestFire/forest_fire.ned
@@ -25,6 +25,8 @@ simple ForestFire like node.application.iApplication {
 
     bool isSink = default(false);
     bool isMaster = default(false);
+    bool noRoleChange = default(false);
+    string Role = default("NonRoot"); // NonRoot, SubRoot, Root
     
 
 //      bool broadcastReports = default(false);

--- a/src/node/communication/routing/hdmrp/hdmrp.h
+++ b/src/node/communication/routing/hdmrp/hdmrp.h
@@ -30,11 +30,14 @@ class hdmrp: public VirtualRouting {
      int t_start;
      hdmrpStateDef state;
      hdmrpRoleDef role;
+     bool no_role_change;
      bool master;
+     double min_rreq_rssi;
      map<int, hdmrp_path> rreq_table;
      std::mt19937 gen(std::random_device());
      map<int, hdmrp_path> routing_table;
      int d_pkt_seq;
+     int sent_data_pkt;
 
  protected:
      void startup();
@@ -57,7 +60,7 @@ class hdmrp: public VirtualRouting {
      void addRoute(const hdmrp_path);
      void clearRoutes();
      hdmrp_path getRoute(const int);
-     hdmrp_path getRoute() const;
+     hdmrp_path getRoute();
      bool RouteExists() const; 
 
      bool isSink() const;

--- a/src/node/communication/routing/hdmrp/hdmrp.ned
+++ b/src/node/communication/routing/hdmrp/hdmrp.ned
@@ -36,6 +36,7 @@ simple hdmrp like node.communication.routing.iRouting
     int t_l = default (1); // Tl timer, default 1 sec
     int t_rreq = default (10); // Trreq timer, default 10 sec
     int t_start = default (1); // sink start timer
+    double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ
 
  gates:
 	output toCommunicationModule;

--- a/src/node/sensorManager/SensorManager.cc
+++ b/src/node/sensorManager/SensorManager.cc
@@ -61,6 +61,9 @@ void SensorManager::handleMessage(cMessage * msg)
 			reg_msg->setSrcID(self);	//insert information about the ID of the node
 			reg_msg->setXCoor(nodeMobilityModule->getLocation().x);
 			reg_msg->setYCoor(nodeMobilityModule->getLocation().y);
+
+            trace()<<"Position x: "<<nodeMobilityModule->getLocation().x<<" y: "<<nodeMobilityModule->getLocation().y;
+
             reg_msg->setEvent(EventType::REGISTER);
 
             // Ugly hack, but at this point we assume that there is only one physical process

--- a/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc
+++ b/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc
@@ -65,8 +65,14 @@ void WildFirePhysicalProcess::handleMessage(cMessage * msg)
             CellPosition pos=getMapCoordinates(phyMsg->getXCoor(), phyMsg->getYCoor());
 
 //            std::cout<<pos<<std::endl;
-
-            CellState state=wf_ca->getState(pos);
+//
+            CellState state;
+            try {
+                state=wf_ca->getState(pos);
+            } catch(std::string &e) {
+                trace()<<"Error: "<<e<<" x: "<<pos.x<<" y: "<<pos.y;
+                return;
+            }
             phyMsg->setValue(convertStateToSensedValue(state));
             // Send reply back to the node who made the request
             send(phyMsg, "toNode", phyMsg->getSrcID());
@@ -91,7 +97,7 @@ void WildFirePhysicalProcess::handleMessage(cMessage * msg)
             trace()<<"Subscription to physical event";
             PhysicalEventMessage *reg_msg=check_and_cast<PhysicalEventMessage *>(msg);
             if(EventType::REGISTER==reg_msg->getEvent()) {
-                trace()<<reg_msg->getSrcID()<<" registered";
+                trace()<<reg_msg->getSrcID()<<" registered. Position x: "<<reg_msg->getXCoor()<<" y: "<<reg_msg->getYCoor();
                 subs.push_back({reg_msg->getSrcID(), reg_msg->getXCoor(), reg_msg->getYCoor()});
             }
             delete msg;


### PR DESCRIPTION
o New omnet config, test_om.ini
o Sampling starts delayed based on node ID's decimal value
o New parameters@ForestFire:
  - noRoleChange - node cannot change role
  - Role - hardcode node's role
o New paramter@HDMRP:
  - min_rreq_rssi - reject (s)RREQ packets with RSSI lower than the defined threshold
o New metrics
  - Originated, forward, received packets (network level)
o hdmrp::getRoute() method throws exception

 Changes to be committed:
	modified:   omnetpp.ini
	new file:   test_om.ini
	modified:   ../../src/node/application/ForestFire/forest_fire.cc
	modified:   ../../src/node/application/ForestFire/forest_fire.ned
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.cc
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.h
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.ned
	modified:   ../../src/node/sensorManager/SensorManager.cc
	modified:   ../../src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc