### PR TITLE
Changes

### DIFF
--- a/Simulations/hdmrp_testbed/test_om.ini
+++ b/Simulations/hdmrp_testbed/test_om.ini
@@ -14,7 +14,7 @@
 
 include ../Parameters/Castalia.ini
 
-sim-time-limit = 10h
+sim-time-limit = 2d10min
 
 
 # ___ _           _         _                              
@@ -29,7 +29,7 @@ SN.physicalProcess[*].no_map_file = true
 SN.physicalProcess[*].wf_start_x_coord = 10
 SN.physicalProcess[*].wf_start_y_coord = 10
 SN.physicalProcess[*].ca_step_period = 2000
-SN.physicalProcess[*].ca_start_timer = 864000
+SN.physicalProcess[*].ca_start_timer = 8640000
 
 
 # ___         _ _     
@@ -78,7 +78,7 @@ SN.node[*].ApplicationName = "ForestFire"
 SN.node[0].Application.isSink = true
 SN.node[*].Application.reportDestination = "0"
 SN.node[*].Application.report_timer_offset = false
-SN.node[*].Application.sampleInterval = 1200
+SN.node[*].Application.sampleInterval = 86400
 
 #SN.node[0..2].Application.isMaster = true 
 #SN.node[7..9].Application.isMaster = true 
@@ -102,8 +102,10 @@ SN.wirelessChannel.pathLossExponent = 2.2
 #|_|_\___/\_,_|\__|_|_||_\__, |
 #                        |___/ 
 SN.node[*].Communication.RoutingProtocolName = "hdmrp"
-SN.node[*].Communication.Routing.t_rreq = 2000
+SN.node[*].Communication.Routing.t_rreq = 200000
 SN.node[*].Communication.Routing.min_rreq_rssi = -89
+SN.node[*].Communication.Routing.t_rsnd = 4
+SN.node[*].Communication.Routing.t_pkt_hist = 30
 
 
 # _____                
@@ -119,14 +121,14 @@ SN.node[*].Communication.Routing.collectTraceInfo = true
 
 SN.physicalProcess[*].collectTraceInfo = true
 #SN.node[*].Application.collectTraceInfo = true
-SN.node[*].SensorManager.collectTraceInfo = true
+#SN.node[*].SensorManager.collectTraceInfo = true
 #SN.node[*].ResourceManager.collectTraceInfo = true
 #SN.node[*].MobilityManager.collectTraceInfo = true
 
 SN.field_x = 180
 SN.field_y = 180
-SN.numNodes = 49
-SN.deployment = "[0..49]->8x8"
+SN.numNodes = 48
+SN.deployment = "[0..47]->8x8"
 
 #SN.deployment = "[0]->center;[1..6]->3x2"
 #SN.node[0].xCoor = 10

--- a/src/node/communication/mac/tMac/TMAC.cc
+++ b/src/node/communication/mac/tMac/TMAC.cc
@@ -549,8 +549,8 @@ void TMAC::fromRadioLayer(cPacket * pkt, double RSSI, double LQI)
 		/* received DATA frame */
 		case DATA_TMAC_PACKET:{
 			// Forward the frame to upper layer first
-			if (isNotDuplicatePacket(macPkt))
-				toNetworkLayer(decapsulatePacket(macPkt));
+			if (isNotDuplicatePacket(macPkt)) 
+               	toNetworkLayer(decapsulatePacket(macPkt));
 
 			// If the frame was sent to broadcast address, nothing else needs to be done
 			if (destination == BROADCAST_MAC_ADDRESS)

--- a/src/node/communication/routing/hdmrp/hdmrp.h
+++ b/src/node/communication/routing/hdmrp/hdmrp.h
@@ -24,12 +24,22 @@ struct hdmrp_path {
     int len;
 };
 
+struct pkt_hist_entry {
+    int orig;
+    unsigned int seq;
+    int l_seq;
+    simtime_t ts;
+};
+
+
 class hdmrp: public VirtualRouting {
  private:
      int round;
      int t_l;
      int t_rreq;
      int t_start;
+     int t_pkt_hist;
+     int t_rsnd;
      hdmrpStateDef state;
      hdmrpRoleDef role;
      bool no_role_change;
@@ -37,8 +47,10 @@ class hdmrp: public VirtualRouting {
      double min_rreq_rssi;
      map<int, hdmrp_path> rreq_table;
      std::mt19937 gen(std::random_device());
-     map<int, hdmrp_path> routing_table;
-     map<unsigned int, hdmrpPacket *> wf_ack_buffer;
+     std::map<int, hdmrp_path> routing_table;
+     std::map<unsigned int, hdmrpPacket *> wf_ack_buffer;
+     std::vector<pkt_hist_entry> pkt_hist;
+
      int d_pkt_seq;
      int sent_data_pkt;
      int recv_pkt;
@@ -91,6 +103,12 @@ class hdmrp: public VirtualRouting {
      int  getRound() const;
 
      void bufferForAck(hdmrpPacket *);
+     bool bufferedPktExists(int index);
+     hdmrpPacket* getBufferedPkt(int index);
+
+     void incrementSeqNum();
+     bool findPktHistEntry(pkt_hist_entry);
+     void addPktHistEntry(pkt_hist_entry);
 
  public:
      set<int> getPaths();

--- a/src/node/communication/routing/hdmrp/hdmrp.msg
+++ b/src/node/communication/routing/hdmrp/hdmrp.msg
@@ -36,13 +36,14 @@ enum hdmrpStateDef {
 }
 
 enum hdmrpTimerDef {
-    SINK_START      = 1;
-    T_L             = 2;
-    ROOT_GUARD      = 3;
-    SUB_ROOT_GUARD  = 4;
-    NEW_ROUND       = 5;
-    T_RELAY         = 6;
-// TIMER ID SHALL BE LESS THAN 8
+    SINK_START       = 1;
+    T_L              = 2;
+    ROOT_GUARD       = 3;
+    SUB_ROOT_GUARD   = 4;
+    NEW_ROUND        = 5;
+    T_RELAY          = 6;
+    ACK_HIST_PURGE   = 7;
+    PACKET_TIMER_1   = 8;
 }
 
 // RREQ = { R, S, P, len, nmas }
@@ -55,5 +56,6 @@ packet hdmrpPacket extends RoutingPacket {
     bool ack_req;
     int rep_count;
     int orig;
+    int l_seq;      // 1 byte
 }
 

--- a/src/node/communication/routing/hdmrp/hdmrp.ned
+++ b/src/node/communication/routing/hdmrp/hdmrp.ned
@@ -37,6 +37,8 @@ simple hdmrp like node.communication.routing.iRouting
     int t_rreq = default (10); // Trreq timer, default 10 sec
     int t_start = default (1); // sink start timer
     double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ
+    int t_pkt_hist  = default (5); // keep pkt history entry at least this long
+    int t_rsnd = default(1); // Resend timer
 
  gates:
 	output toCommunicationModule;


### PR DESCRIPTION
o Fine tune test_om.ini file to test HARQ protocol
o New timers (and parameters):
  - t_rsnd - timer that defines resend period
  - t_pkt_hist - timer that defines ack history cleanup period and minimum buffer age
o New buffers, wf_ack_buffer and pkt_hist
o New helper functions to store/retrieve/check pkts from wf_ack_buffer and pkt_hist
o Timer handling for t_rsnd and t_pkt_hist
o Buffer handling for the new buffers
o New struct pkt_hist_entry
o New sequence number l_seq, to keep track of h2h communication