### PR TITLE
Changes

### DIFF
--- a/Simulations/hdmrp_testbed/test_om.ini
+++ b/Simulations/hdmrp_testbed/test_om.ini
@@ -14,7 +14,7 @@
 
 include ../Parameters/Castalia.ini
 
-sim-time-limit = 4h
+sim-time-limit = 1d12h
 
 
 # ___ _           _         _                              
@@ -27,9 +27,10 @@ SN.physicalProcess[*].map_file = "bundle_small.bin"
 SN.physicalProcess[*].map_scale = 1
 SN.physicalProcess[*].no_map_file = true
 SN.physicalProcess[*].wf_start_x_coord = 179
-SN.physicalProcess[*].wf_start_y_coord = 179
-SN.physicalProcess[*].ca_step_period = 100
-SN.physicalProcess[*].ca_start_timer = 1200
+SN.physicalProcess[*].wf_start_y_coord = 0
+SN.physicalProcess[*].ca_step_period = 1200
+SN.physicalProcess[*].ca_start_timer = 20000
+SN.physicalProcess[*].seed = 10 
 
 
 # ___         _ _     
@@ -79,10 +80,12 @@ SN.node[0].Application.isSink = true
 SN.node[*].Application.reportDestination = "0"
 SN.node[*].Application.report_timer_offset = false
 #SN.node[*].Application.sampleInterval = 2000
-SN.node[16].Application.isMaster = true
-SN.node[17].Application.isMaster = true
-SN.node[25].Application.isMaster = true
-SN.node[26].Application.isMaster = true
+#SN.node[16].Application.isMaster = true
+#SN.node[17].Application.isMaster = true
+#SN.node[25].Application.isMaster = true
+#SN.node[26].Application.isMaster = true
+SN.node[*].Application.isMaster = true
+
 
 #SN.node[0..2].Application.isMaster = true 
 #SN.node[7..9].Application.isMaster = true 
@@ -110,7 +113,7 @@ SN.node[*].Communication.Routing.t_rreq = 200000
 SN.node[*].Communication.Routing.min_rreq_rssi = -89
 SN.node[*].Communication.Routing.t_rsnd = 4
 SN.node[*].Communication.Routing.t_pkt_hist = 30
-
+SN.node[*].Communication.Routing.send_path_failure = true
 
 # _____                
 #|_   _| _ __ _ __ ___ 

--- a/src/node/application/ForestFire/forest_fire.cc
+++ b/src/node/application/ForestFire/forest_fire.cc
@@ -48,6 +48,8 @@ void ForestFire::startup()
         }
 	}
     emergency=false;
+	declareOutput("Report packet");
+	declareOutput("Event packet");
 }
 
 void ForestFire::sendEvent() {
@@ -59,6 +61,7 @@ void ForestFire::sendEvent() {
     newPkt->setByteLength(2);
 	toNetworkLayer(newPkt, reportDestination.c_str());
 	currSampleSN++;
+    collectOutput("Event packet","Sent");
 }
 
 void ForestFire::sendReport() {
@@ -70,6 +73,7 @@ void ForestFire::sendReport() {
     newPkt->setByteLength(2);
 	toNetworkLayer(newPkt, reportDestination.c_str());
 	currSampleSN++;
+    collectOutput("Report packet","Sent");
 }
 
 void ForestFire::sendEmergencyBroadcast() {
@@ -134,7 +138,8 @@ void ForestFire::fromNetworkLayer(ApplicationPacket * rcvPacket,
         }
     }
 
-	if (packetName.compare(REPORT_PACKET_NAME) == 0) {
+    else	if (packetName.compare(REPORT_PACKET_NAME) == 0) {
+        collectOutput("Report packet","Received");
 		// this is report packet which contains sensor reading information
 		// NOTE that data field is used to store source address instead of using char *source
 		// this is done because some routing and flooding is done on the application layer
@@ -158,6 +163,9 @@ void ForestFire::fromNetworkLayer(ApplicationPacket * rcvPacket,
 //		}
 
 //	}
+    else    if(0==packetName.compare(EVENT_PACKET_NAME)) {
+        collectOutput("Event packet","Received");
+    }
 		else {
 		trace() << "unknown packet received: [" << packetName << "]";
 	}
@@ -197,7 +205,6 @@ void ForestFire::handleSensorReading(SensorReadingMessage * sensorMsg)
 	//	return;
 	//}
     //
-	trace() << "Sending report packet, sequence number " << currSampleSN;
 
 }
 

--- a/src/node/communication/routing/hdmrp/hdmrp.h
+++ b/src/node/communication/routing/hdmrp/hdmrp.h
@@ -59,6 +59,7 @@ class hdmrp: public VirtualRouting {
      hdmrpRoleDef role;
      bool no_role_change;
      bool master;
+     bool send_path_failure;
      double min_rreq_rssi;
      map<int, hdmrp_path> rreq_table;
      std::mt19937 gen(std::random_device());

--- a/src/node/communication/routing/hdmrp/hdmrp.ned
+++ b/src/node/communication/routing/hdmrp/hdmrp.ned
@@ -42,6 +42,7 @@ simple hdmrp like node.communication.routing.iRouting
     int rep_limit = default(3); // give after rep_limit and send path failure // give after rep_limit and send path failure
     int report_ack_period = default(10);
     int event_ack_req_period = default (10);
+    bool send_path_failure = default(true);
 
  gates:
 	output toCommunicationModule;

--- a/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc
+++ b/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc
@@ -29,6 +29,8 @@ void WildFirePhysicalProcess::initialize()
         sim_y_size=static_cast<int>(tmp_sim_y_size);
     }
 
+    seed=par("seed");
+
     std::vector<unsigned char> map_buffer;
     int map_x_size;
     int map_y_size;
@@ -40,7 +42,7 @@ void WildFirePhysicalProcess::initialize()
         }
         map_x_size=sim_x_size/map_scale;
         map_y_size=sim_y_size/map_scale;
-        wf_ca=new WildFireCA(map_x_size, map_y_size,{ 0.58, 0.045, 0.131, 0.078, 0, 8.1, static_cast<float>(map_scale),true});
+        wf_ca=new WildFireCA(map_x_size, map_y_size,{ 0.58, 0.045, 0.131, 0.078, 3.92, 8.1, static_cast<float>(map_scale),true, seed});
     } else {
         map_buffer=readMapFile();
         getMapSize(map_buffer,map_x_size,map_y_size);
@@ -50,7 +52,7 @@ void WildFirePhysicalProcess::initialize()
        GridCell **plane=generatePlane(map_buffer, map_x_size, map_y_size);
 
        if(plane) {
-           wf_ca=new WildFireCA(map_x_size, map_y_size,{ 0.58, 0.045, 0.131, 0.078, 0, 8.1, static_cast<float>(map_scale),true}, plane);
+           wf_ca=new WildFireCA(map_x_size, map_y_size,{ 0.58, 0.045, 0.131, 0.078, 3.92, 8.1, static_cast<float>(map_scale),true,seed}, plane);
            deletePlane(plane, map_x_size);
        } else {
            throw cRuntimeError("Cannot generate plane\n");
@@ -64,6 +66,7 @@ void WildFirePhysicalProcess::initialize()
 
     trace() << "Firt CA step at: "<<ca_start_timer<<" seconds";
     scheduleAt(SimTime()+static_cast<double>(ca_start_timer), new cMessage("CA step timer expired", TIMER_SERVICE));
+
 }
 
 void WildFirePhysicalProcess::handleMessage(cMessage * msg)

--- a/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.h
+++ b/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.h
@@ -44,6 +44,7 @@ class WildFirePhysicalProcess: public CastaliaModule {
 	const char *description;
     WildFireCA *wf_ca;
     std::vector<nodeLocation> subs;
+    int seed;
 
  protected:
 	virtual void initialize();

--- a/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.ned
+++ b/src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.ned
@@ -24,6 +24,7 @@ parameters:
     int     map_scale = default (90);
     int     ca_step_period;
     int     ca_start_timer;
+    int     seed = default(0);
 
 	string  description = default ("CA based wildfire");
 


### PR DESCRIPTION
o Bugfix: Don't route a packet, if there is no route due to learning state
o New measurements (event and report packets total sent, total received)
o Wildfire model's seed via parameter

 Changes to be committed:
	modified:   Simulations/hdmrp_testbed/test_om.ini
	modified:   src/node/application/ForestFire/forest_fire.cc
	modified:   src/node/communication/routing/hdmrp/hdmrp.cc
	modified:   src/node/communication/routing/hdmrp/hdmrp.h
	modified:   src/node/communication/routing/hdmrp/hdmrp.ned
	modified:   src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.cc
	modified:   src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.h
	modified:   src/physicalProcess/WildFirePhysicalProcess/WildFirePhysicalProcess.ned
	modified:   src/physicalProcess/WildFirePhysicalProcess/wf.h