### PR TITLE
Changes:

### DIFF
--- a/Simulations/throughputTest/omnetpp.ini
+++ b/Simulations/throughputTest/omnetpp.ini
@@ -18,14 +18,18 @@
 include ../Parameters/Castalia.ini
 
 
-sim-time-limit = 1h
+sim-time-limit = 5min
+seed-set = ${runnumber}
 
-SN.field_x = 100	# meters
-SN.field_y = 100	# meters
+SN.field_x = 160	# meters
+SN.field_y = 160	# meters
 
 # These tests include 3 nodes each, coordinates will be specified manually
-SN.numNodes = 25
-SN.deployment = "[0..24]->5x5"
+SN.numNodes = 64
+#SN.deployment = "[0..63]->randomized_8x8"
+SN.deployment = "[1..63]->8x8"
+SN.node[0].xCoor = 160
+SN.node[0].yCoor = 160
 
 # important wireless channel switch to allow mobility
 SN.wirelessChannel.onlyStaticNodes = true
@@ -42,18 +46,22 @@ SN.node[*].Communication.Radio.TxOutputPower = "0dBm"
 
 # These tests use big packets (2kb) to show interference clearly
 # This requires to set the max pkt size in all communication layers
-SN.node[*].Communication.Routing.maxNetFrameSize = 200
-SN.node[*].Communication.MAC.macMaxPacketSize = 200
-SN.node[*].Communication.Radio.maxPhyFrameSize = 200
+#SN.node[*].Communication.Routing.maxNetFrameSize = 200
+#SN.node[*].Communication.MAC.macMaxPacketSize = 200
+#SN.node[*].Communication.Radio.maxPhyFrameSize = 200
 
 # Throughput test application is used to send 2000-byte
 # packets to node 0 (which by default is the receiving 
 # node for this app).5 packets per second will be send 
 SN.node[*].ApplicationName = "ThroughputTest"
-SN.node[*].Application.packet_rate = 5
-#SN.node[*].Application.constantDataPayload = 170
+#SN.node[*].Application.packet_rate = ${rate=0.1,0.2,0.5,1,2}
+SN.node[*].Application.packet_rate = 0.1
+SN.node[*].Application.startupDelay = 10 
+
+SN.node[0].Application.isSink = true
+SN.node[*].Application.constantDataPayload = 20
 #SN.node[*].Application.packetRepetition = 0 #${Repetition=0,1,2,3,4,5,6,7,8,9,10,20}
-SN.wirelessChannel.pathLossExponent = 2
+SN.wirelessChannel.pathLossExponent = 2.2
 #SN.wirelessChannel.temporalModelParametersFile = "../Parameters/WirelessChannel/BANmodels/TemporalModel.txt"
 SN.node[*].Communication.Radio.collisionModel = 2
 
@@ -63,14 +71,23 @@ SN.node[*].Communication.MACProtocolName = "TMAC"
 #SN.node[*].Communication.MAC.allowSinkSync = false
 #SN.node[*].ResourceManager.sigmaCPUClockDrift = 0.00003
 
-SN.node[*].Communication.RoutingProtocolName = "flooding"
+SN.node[*].Communication.RoutingProtocolName = "hdmrp"
+SN.node[*].Communication.Routing.t_rreq = 2000000
+SN.node[*].Communication.Routing.default_ack = true
+SN.node[*].Communication.Routing.send_path_failure = false
+SN.node[*].Communication.Routing.t_rsnd = 1 
+SN.node[*].Communication.Routing.min_rreq_rssi = -90
+SN.node[*].Communication.Routing.t_pkt_hist = 20
+#SN.node[*].Communication.Routing.t_l = ${1,2,3,5,7,10,12}
+SN.node[*].Communication.Routing.t_l = 10
 
+SN.node[*].Communication.Routing.store_all_paths = true
 # application's trace info for node 0 (receiving node)
 # is turned on, to show some interesting patterns
 #SN.node[*].Application.collectTraceInfo = true
-SN.node[*].Communication.MAC.collectTraceInfo = true
-SN.wirelessChannel.collectTraceInfo = true
-SN.node[*].Communication.Routing.collectTraceInfo = true
+#SN.node[*].Communication.MAC.collectTraceInfo = true
+#SN.wirelessChannel.collectTraceInfo = true
+#SN.node[*].Communication.Routing.collectTraceInfo = true
 
 #SN.physicalProcess[*].collectTraceInfo = true
 
@@ -107,6 +124,10 @@ SN.node[*].MobilityManagerName = "NoMobilityManager"
 # static nodes 0 and 1 is disrupted when mobile node 2
 # passes between them.
 # =========================================================
+
+[Config t_l]
+SN.node[*].Communication.Routing.t_l = 1
+
 
 [Config InterferenceTest1]
 

--- a/src/node/application/throughputTest/ThroughputTest.cc
+++ b/src/node/application/throughputTest/ThroughputTest.cc
@@ -95,7 +95,6 @@ void ThroughputTest::finishSpecific() {
 	cTopology *topo;	// temp variable to access packets received by other nodes
 	topo = new cTopology("topo");
 	topo->extractByNedTypeName(cStringTokenizer("node.Node").asVector());
-
 	long bytesDelivered = 0;
 	for (int i = 0; i < numNodes; i++) {
 		ThroughputTest *appModule = dynamic_cast<ThroughputTest*>
@@ -103,9 +102,10 @@ void ThroughputTest::finishSpecific() {
 		if (appModule) {
 			int packetsSent = appModule->getPacketsSent(self);
 			if (packetsSent > 0) { // this node sent us some packets
-				float rate = (float)packetsReceived[i]/packetsSent;
+				float rate = (float)packetsReceived[i]/(float)packetsSent;
 				collectOutput("Packets reception rate", i, "total", rate);
 				collectOutput("Packets loss rate", i, "total", 1-rate);
+                trace()<<"Pkt received: "<<packetsReceived[i]<<" sent: "<<packetsSent;
 			}
 
 			bytesDelivered += appModule->getBytesReceived(self);

--- a/src/node/application/throughputTest/ThroughputTest.ned
+++ b/src/node/application/throughputTest/ThroughputTest.ned
@@ -35,6 +35,10 @@ simple ThroughputTest like node.application.iApplication {
 
 	double latencyHistogramMax = default (200.0);
 	int latencyHistogramBuckets = default (10);
+    bool isSink = default (false);
+    string Role = default("NonRoot"); // NonRoot, SubRoot, Root
+    bool noRoleChange = default(false);
+
 
  gates:
  	output toCommunicationModule;

--- a/src/node/communication/routing/hdmrp/hdmrp.h
+++ b/src/node/communication/routing/hdmrp/hdmrp.h
@@ -12,11 +12,16 @@
 
 #include <random>
 #include <algorithm>
+#include <map>
+#include <fstream>
+#include <unordered_set>
+#include <ctime> 
 
 #include "node/communication/routing/VirtualRouting.h"
 #include "node/communication/routing/hdmrp/hdmrp_m.h"
 #include "node/application/ApplicationPacket_m.h"
 #include "node/application/ForestFire/forest_fire_packet_m.h"
+#include "node/mobilityManager/VirtualMobilityManager.h"
 
 struct hdmrp_path {
     int path_id;
@@ -53,7 +58,7 @@ class hdmrp: public VirtualRouting {
      int t_rreq;
      int t_start;
      int t_pkt_hist;
-     int t_rsnd;
+     double t_rsnd;
      int rep_limit;
      int event_ack_req_period;
      int event_pkt_counter;
@@ -68,12 +73,14 @@ class hdmrp: public VirtualRouting {
      bool minor_rreq;
      bool failing;
      int resel_limit;
+     bool default_ack;
      map<int, hdmrp_path> rreq_table;
      std::mt19937 gen(std::random_device());
      std::map<int, hdmrp_path> routing_table;
      std::map<unsigned int, hdmrpPacket *> wf_ack_buffer;
      std::vector<pkt_hist_entry> pkt_hist;
      std::map<int, neigh_entry> neigh_list;
+     std::unordered_set<int> root_table;
 
      int d_pkt_seq;
      int sent_data_pkt;
@@ -134,6 +141,11 @@ class hdmrp: public VirtualRouting {
      void setRound(int);
      int  getRound() const;
 
+     bool isSameRoot(int) const;
+     void addRoot(int);
+     void clearRootTable(); 
+     int  selectRoot() const;
+
      void initMinorRound();
      void newMinorRound();
      bool isNewMinorRound(hdmrpPacket*) const;
@@ -165,7 +177,10 @@ class hdmrp: public VirtualRouting {
 
  public:
      set<int> getPaths();
-
+     map<int,string> getPathsAndHops();
+     vector<int> getNeighbors();
+     hdmrpRoleDef getRole() const;
+     static std::string roleToStr(hdmrpRoleDef);
 };
 
 #endif //HDMRP

--- a/src/node/communication/routing/hdmrp/hdmrp.ned
+++ b/src/node/communication/routing/hdmrp/hdmrp.ned
@@ -39,7 +39,7 @@ simple hdmrp like node.communication.routing.iRouting
     int t_start = default (1); // sink start timer
     double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ
     int t_pkt_hist  = default (5); // keep pkt history entry at least this long
-    int t_rsnd = default(1); // Resend timer
+    double t_rsnd = default(1); // Resend timer
     int rep_limit = default(3); // give after rep_limit and send path failure // give after rep_limit and send path failure
     int report_ack_period = default(10);
     int event_ack_req_period = default (10);
@@ -47,7 +47,8 @@ simple hdmrp like node.communication.routing.iRouting
     bool store_all_paths   = default(false);
     bool path_confirm      = default(true);
     bool minor_rreq        = default(true);
-    int resel_limit        = default(3);
+    int  resel_limit       = default(3);
+    bool default_ack       = default(false);
 
  gates:
 	output toCommunicationModule;

--- a/src/node/mobilityManager/VirtualMobilityManager.cc
+++ b/src/node/mobilityManager/VirtualMobilityManager.cc
@@ -85,12 +85,12 @@ void VirtualMobilityManager::parseDeployment() {
 			nodeLocation.x = uniform(0, xlen);
 			nodeLocation.y = uniform(0, ylen);
 			nodeLocation.z = uniform(0, zlen);
-			return;
+			break;
 		} else if (strncmp(c, "center", strlen("center")) == 0) {
 			nodeLocation.x = xlen/2;
 			nodeLocation.y = ylen/2;
 			nodeLocation.z = zlen/2;
-			return; 			
+			break; 			
 		} else if (strncmp(c, "randomized_", strlen("randomized_")) == 0) {
 			c += strlen("randomized_");
 			random_flag = 1;
@@ -144,11 +144,13 @@ void VirtualMobilityManager::parseDeployment() {
 					nodeLocation.z = 0;
 			}
 		}
-		return;
+		break;
 	}
-	nodeLocation.x = node->par("xCoor");
-	nodeLocation.y = node->par("yCoor");
-	nodeLocation.z = node->par("zCoor");
+    if(par("positionOverride")) {
+    	nodeLocation.x = node->par("xCoor");
+    	nodeLocation.y = node->par("yCoor");
+        nodeLocation.z = node->par("zCoor");
+    }
 }
 
 void VirtualMobilityManager::setLocation(double x, double y, double z, double phi, double theta)

--- a/src/node/mobilityManager/noMobilityManager/NoMobilityManager.ned
+++ b/src/node/mobilityManager/noMobilityManager/NoMobilityManager.ned
@@ -14,5 +14,6 @@ package node.mobilityManager.noMobilityManager;
 
 simple NoMobilityManager like node.mobilityManager.iMobilityManager {
  parameters:
+    bool positionOverride = default (false);
 	bool collectTraceInfo = default (false);
 }


### PR DESCRIPTION
 - Predefined roles for HDMRP finally work (SubRoot, NonRoot, Sink, Root)
   Unfortunately, you still have to use isSink=true. xD
 - It is possible to use an arbitrary SN.deployment and override certain
   node's coordinate like:
   SN.deployment = "[0..15]->4x4"
   SN.node[0].xCoor = 1
   SN.node[0].yCoor = 1
   Howver, SN.node.positionOverride = true is needed (new parameter)
 - HDMRP SubRoots are able to randomly select a subsequent Root, once
   they receive a new RREQ with Path=0:
   o Every SubRoot maintains a root_table (how original, how unambiguous)
   o Once a RREQ is received by a SubRoot, the table is updated with
     the sender's id and a new Root is selected randomly
   o throughputTest
 - HDMRP is able to write positions, neighbours and routes to .py
   data structures
 - HDMRP: default_ack parameter, always require ack for HDMRP messages

 Changes to be committed:
	modified:   omnetpp.ini
	modified:   ../../src/node/application/throughputTest/ThroughputTest.cc
	modified:   ../../src/node/application/throughputTest/ThroughputTest.ned
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.cc
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.h
	modified:   ../../src/node/communication/routing/hdmrp/hdmrp.ned
	modified:   ../../src/node/mobilityManager/VirtualMobilityManager.cc
	modified:   ../../src/node/mobilityManager/noMobilityManager/NoMobilityManager.ned