### PR TITLE
New features

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -57,23 +57,34 @@ enum shmrpRingDef {
     EXTERNAL = 3
 };
 
+enum shmrpCostFuncDef {
+    NOT_DEFINED    = 0,
+    HOP            = 1,
+    HOP_AND_INTERF = 2
+};
+
 
 //namespace shmrp {
     class rreq_table_empty : public std::runtime_error {
         public:
-            rreq_table_empty(const string &what_arg) : std::runtime_error(what_arg) {};
-            rreq_table_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
+            explicit rreq_table_empty(const string &what_arg) : std::runtime_error(what_arg) {};
+            explicit rreq_table_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
     };
 
     class rinv_table_empty : public std::runtime_error {
         public:
-            rinv_table_empty(const string &what_arg) : std::runtime_error(what_arg) {};
-            rinv_table_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
+            explicit rinv_table_empty(const string &what_arg) : std::runtime_error(what_arg) {};
+            explicit rinv_table_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
     };
     class rreq_table_non_empty : public std::runtime_error {
         public:
-            rreq_table_non_empty(const string &what_arg) : std::runtime_error(what_arg) {};
-            rreq_table_non_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
+            explicit rreq_table_non_empty(const string &what_arg) : std::runtime_error(what_arg) {};
+            explicit rreq_table_non_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
+    };
+    class routing_table_empty : public std::runtime_error {
+        public:
+            explicit routing_table_empty(const string &what_arg) : std::runtime_error(what_arg) {};
+            explicit routing_table_empty(const char   *what_arg) : std::runtime_error(what_arg) {};
     };
 
 //}
@@ -83,6 +94,7 @@ struct node_entry {
     int pathid;
     int hop;
     bool rresp = false;
+    int interf;
 };
 
 struct feat_par {
@@ -91,6 +103,10 @@ struct feat_par {
         double t_est;
         bool   rresp_req;
         bool   rst_learn;
+        bool   replay_rinv;
+        shmrpCostFuncDef cost_func;
+        double cost_func_alpha;
+        double cost_func_beta;
 };
 
 class shmrp: public VirtualRouting {
@@ -111,6 +127,8 @@ class shmrp: public VirtualRouting {
         void fromMacLayer(cPacket *, int, double, double);
         void timerFiredCallback(int);
         void finishSpecific();
+
+        shmrpCostFuncDef strToCostFunc(string) const;
 
         bool isSink() const;
         void setSinkAddress(const char *);
@@ -140,9 +158,11 @@ class shmrp: public VirtualRouting {
         void updateRreqTableWithRresp(const char *, int);
         bool rrespReceived() const;
 
+        double routeCostFunction(node_entry) const;
+
 
         void clearRoutingTable();
-        void constructRoutingTable();
+        void constructRoutingTable(bool);
         int  selectPathid();
 
         void sendRreqs();

--- a/src/node/communication/routing/shmrp/shmrp.msg
+++ b/src/node/communication/routing/shmrp/shmrp.msg
@@ -32,6 +32,7 @@ packet shmrpRinvPacket extends shmrpPacket {
     int round;      // 2 byte
     int pathid;     // 1 byte
     int hop;        // 2 byte
+    int interf;      // 1 byte
 }
 
 packet shmrpRreqPacket extends shmrpPacket {

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -29,20 +29,24 @@ simple shmrp like node.communication.routing.iRouting
 //====================================================================================
 {
  parameters:
-	bool collectTraceInfo = default (false);
-	int maxNetFrameSize = default (0);	     // bytes
-	int netDataFrameOverhead = default (10); // bytes
-	int netBufferSize = default (32);	     // number of messages
-    double t_l = default (1);                // Tl timer, default 1 sec
-    double t_est = default(2);               // Test timer, default 2 sec
-    int ring_radius = default(2);            // Root radius in hops
+	bool   collectTraceInfo = default (false);
+	int    maxNetFrameSize = default (0);	    // bytes
+	int    netDataFrameOverhead = default (10); // bytes
+	int    netBufferSize = default (32);	    // number of messages
+    double t_l = default (1);                   // Tl timer, default 1 sec
+    double t_est = default(2);                  // Test timer, default 2 sec
+    int    ring_radius = default(2);            // Root radius in hops
 
-    double t_relay = default(0.1);           // relay timer
-    double t_start = default (1);            // sink start timer
-    string sink_address = default("0");           // sink's network address
+    double t_relay = default(0.1);              // relay timer
+    double t_start = default (1);               // sink start timer
+    string sink_address = default("0");         // sink's network address
 
-    bool f_rresp_required = default(false);   // Expect RRESP to use route
-    bool f_restart_learning = default(false); // Restart learning if isolated
+    bool   f_rresp_required   = default(false); // Expect RRESP to use route
+    bool   f_restart_learning = default(false); // Restart learning if isolated
+    bool   f_replay_rinv      = default(false); // Ask neighbours to re-send RINVs within round
+    string f_cost_function    = default("hop"); // Cost Functions, available: hop, hopandinterf
+    double f_cost_func_alpha  = default(1.0);   // Alpha coeff. in cost function,  controls hop term
+    double f_cost_func_beta   = default(1.0);   // Beta coeff. in cost function, controls interference term
 
 
     int t_rreq = default (10); // Trreq timer, default 10 sec


### PR DESCRIPTION
- Replay RINV - explicitly ask for RINV messages to be sent, only parameter placeholder
- cost function - two cost function (hop and hopandinterf) available, with alpha and beta coefficients

Other
- New exceptions
- New enum datatypes
- Rationalize failure case behaviours

 Changes to be committed:
	modified:   ../../src/node/communication/routing/shmrp/shmrp.cc
	modified:   ../../src/node/communication/routing/shmrp/shmrp.h
	modified:   ../../src/node/communication/routing/shmrp/shmrp.msg
	modified:   ../../src/node/communication/routing/shmrp/shmrp.ned