### PR TITLE
RINV table admin

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -65,6 +65,13 @@ enum shmrpCostFuncDef {
     HOP_EMERG_AND_INTERF = 3,
 };
 
+enum shmrpRinvTblAdminDef {
+    UNDEF_ADMIN    = 0,
+    ERASE_ON_LEARN = 1,
+    ERASE_ON_ROUND = 2,
+    NEVER_ERASE    = 3 
+};
+
 
 //namespace shmrp {
     class rreq_table_empty : public std::runtime_error {
@@ -112,6 +119,7 @@ struct feat_par {
         double cost_func_beta;
         bool  random_t_l;
         double random_t_l_sigma;
+        shmrpRinvTblAdminDef rinv_tbl_admin;
 };
 
 class shmrp: public VirtualRouting {
@@ -132,7 +140,8 @@ class shmrp: public VirtualRouting {
         void fromMacLayer(cPacket *, int, double, double);
         void timerFiredCallback(int);
         void finishSpecific();
-
+        
+        shmrpRinvTblAdminDef strToRinvTblAdmin(string) const; 
         shmrpCostFuncDef strToCostFunc(string) const;
 
         bool isSink() const;

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -49,6 +49,7 @@ simple shmrp like node.communication.routing.iRouting
     double f_cost_func_beta   = default(1.0);   // Beta coeff. in cost function, controls interference term
     bool   f_random_t_l       = default(false); // Randomize Tl timer
     double f_random_t_l_sigma = default(0.2);   // Sigma parameter of random Tl timer, where Tl is mu
+    string f_rinv_table_admin = default("erase_on_learn"); // How to handle RINV table, available: erase_on_learn, erase_on_round, never_erase 
 
     int t_rreq = default (10); // Trreq timer, default 10 sec
         double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ


### PR DESCRIPTION
New feature
- f_rinv_table_admin parameter, available values:
  - erase_on_learn - Erase RINV table once learning (re)starts
  - erase_on_round - Only erase, if new round starts
  - never_erase    - ¯\_(ツ)_/¯

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.ned