### PR TITLE
New pameter:

### DIFF
--- a/Simulations/shmrp/omnetpp.ini
+++ b/Simulations/shmrp/omnetpp.ini
@@ -101,6 +101,7 @@ SN.node[*].Communication.Routing.f_interf_ping = true
 SN.node[*].Communication.Routing.f_round_keep_pong = true
 SN.node[*].Communication.Routing.f_cost_function = "hop_and_interf"
 SN.node[*].Communication.Routing.f_rand_ring_hop = true
+SN.node[*].Communication.Routing.f_cf_after_rresp = true
 
 
 #SN.node[*].Communication.RoutingProtocolName = "flooding"

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -140,6 +140,7 @@ struct feat_par {
         shmrpCostFuncDef cost_func;
         double cost_func_alpha;
         double cost_func_beta;
+        bool   cf_after_rresp;
         bool   random_t_l;
         double random_t_l_sigma;
         shmrpRinvTblAdminDef rinv_tbl_admin;
@@ -218,6 +219,7 @@ class shmrp: public VirtualRouting {
 
         void clearRoutingTable();
         void constructRoutingTable(bool);
+        void constructRoutingTable(bool,bool);
         bool isRoutingTableEmpty() const;
         int  selectPathid();
         std::string getNextHop(int);

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -48,6 +48,8 @@ simple shmrp like node.communication.routing.iRouting
     string f_cost_function    = default("hop"); // Cost Functions, available: hop, hop_and_interf, hop_emerg_and_interf
     double f_cost_func_alpha  = default(1.0);   // Alpha coeff. in cost function,  controls emerg term
     double f_cost_func_beta   = default(1.0);   // Beta coeff. in cost function, controls interference term
+    bool   f_cf_after_rresp   = default(false); // Apply cost function based selection after RREQ/RRESP
+
     bool   f_random_t_l       = default(false); // Randomize Tl timer
     double f_random_t_l_sigma = default(0.2);   // Sigma parameter of random Tl timer, where Tl is mu
     string f_rinv_table_admin = default("erase_on_learn"); // How to handle RINV table, available: erase_on_learn, erase_on_round, never_erase 


### PR DESCRIPTION
- f_cf_after_rresp - Perform cost function after RREQ/RRESP on certainly working nodes

 Changes to be committed:
	modified:   Simulations/shmrp/omnetpp.ini
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.ned