### PR TITLE
Signal TMAC frame transfer information to Network layer

### DIFF
--- a/Simulations/shmrp/omnetpp.ini
+++ b/Simulations/shmrp/omnetpp.ini
@@ -97,10 +97,11 @@ SN.node[*].Communication.Routing.f_random_t_l = true
 SN.node[*].Communication.Routing.f_random_t_l_sigma = 0.08
 SN.node[*].Communication.Routing.f_rinv_table_admin = "erase_on_round"
 SN.node[*].Communication.Routing.ring_radius = 2
+SN.node[*].Communication.Routing.t_est = 3
 SN.node[*].Communication.Routing.f_interf_ping = true
 SN.node[*].Communication.Routing.f_round_keep_pong = true
 SN.node[*].Communication.Routing.f_cost_function = "hop_and_interf"
-SN.node[*].Communication.Routing.f_rand_ring_hop = true
+#SN.node[*].Communication.Routing.f_rand_ring_hop = true
 #SN.node[*].Communication.Routing.f_cf_after_rresp = ${CFA=false,true}
 SN.node[*].Communication.Routing.f_cf_after_rresp = true
 

--- a/src/node/communication/mac/MacPacket.msg
+++ b/src/node/communication/mac/MacPacket.msg
@@ -12,6 +12,9 @@
 
 enum MacControlMessage_type {
 	MAC_BUFFER_FULL = 1;
+    PKT_SENT        = 2;
+    ACK_RECV        = 3;
+    PKT_FAIL        = 4;
 }
 
 // We need to pass information between MAC and the Radio which is external

--- a/src/node/communication/mac/tMac/TMAC.h
+++ b/src/node/communication/mac/tMac/TMAC.h
@@ -131,6 +131,8 @@ class TMAC: public VirtualMac {
 	void extendActivePeriod(simtime_t extra = 0);
 	void checkTxBuffer();
 	void popTxBuffer();
+    void sendTmacControlMessage(MacControlMessage_type mt, int destination, unsigned int seq_num);
+
 };
 
 #endif				//TMACMODULE

--- a/src/node/communication/mac/tMac/TMacPacket.msg
+++ b/src/node/communication/mac/tMac/TMacPacket.msg
@@ -49,3 +49,9 @@ packet TMacPacket extends MacPacket {
 	int syncId = 0;						// 4 bytes
 }
 
+class MacControlMessage;
+
+message TMacControlMessage extends MacControlMessage {
+    int destination;
+    unsigned int seq_num;
+}   

--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -1121,3 +1121,13 @@ void shmrp::finishSpecific() {
     }
     return;
 }
+
+void shmrp::handleMacControlMessage(cMessage *msg) {
+    trace()<<"[info] Entering handleMacControlMessage()";
+    TMacControlMessage *mac_msg=check_and_cast<TMacControlMessage *>(msg);
+    if(!mac_msg) {
+        trace()<<"[error] Not TMacControlMessage";
+    }
+    trace()<<"[info] Event: "<<mac_msg->getMacControlMessageKind()<<" Node: "<<mac_msg->getDestination()<<" Seqnum: "<<mac_msg->getSeq_num();
+    delete msg;
+}

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -24,6 +24,7 @@
 #include "node/application/ApplicationPacket_m.h"
 #include "node/application/ForestFire/forest_fire_packet_m.h"
 #include "node/mobilityManager/VirtualMobilityManager.h"
+#include "node/communication/mac/tMac/TMacPacket_m.h"
 
 ////enum hdmrpRoleDef {
 ////    SINK        = 1;
@@ -248,7 +249,7 @@ class shmrp: public VirtualRouting {
         void serializeRecvTable(std::map<std::string,node_entry>);
         std::string StateToString(shmrpStateDef);
  
-
+        virtual void handleMacControlMessage(cMessage *);
     public:
         shmrpRingDef getRingStatus() const;
         shmrpStateDef getState() const;


### PR DESCRIPTION
Events signaled:
- Sent
- Ack'd
- Failed

Information:
MAC, seq num

 Changes to be committed:
	modified:   Simulations/shmrp/omnetpp.ini
	modified:   src/node/communication/mac/MacPacket.msg
	modified:   src/node/communication/mac/tMac/TMAC.cc
	modified:   src/node/communication/mac/tMac/TMAC.h
	modified:   src/node/communication/mac/tMac/TMacPacket.msg
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h