### PR TITLE
Measurement with RREQ rewritten

### DIFF
--- a/Simulations/shmrp/omnetpp.ini
+++ b/Simulations/shmrp/omnetpp.ini
@@ -59,7 +59,7 @@ SN.node[*].Communication.Radio.TxOutputPower = "0dBm"
 #SN.node[*].Communication.Routing.maxNetFrameSize = 200
 #SN.node[*].Communication.MAC.macMaxPacketSize = 200
 #SN.node[*].Communication.Radio.maxPhyFrameSize = 200
-SN.node[*].Communication.MAC.macBufferSize = 256
+SN.node[*].Communication.MAC.macBufferSize = 64
 
 # Throughput test application is used to send 2000-byte
 # packets to node 0 (which by default is the receiving 
@@ -99,7 +99,7 @@ SN.node[*].Communication.Routing.f_random_t_l = true
 SN.node[*].Communication.Routing.f_random_t_l_sigma = 0.08
 SN.node[*].Communication.Routing.f_rinv_table_admin = "erase_on_round"
 SN.node[*].Communication.Routing.ring_radius = 2
-SN.node[*].Communication.Routing.t_est = 10
+#SN.node[*].Communication.Routing.t_est = 2
 SN.node[*].Communication.Routing.f_interf_ping = true
 SN.node[*].Communication.Routing.f_round_keep_pong = true
 SN.node[*].Communication.Routing.f_cost_function = "hop_pdr_and_interf"
@@ -110,7 +110,7 @@ SN.node[*].Communication.Routing.f_cf_after_rresp = true
 SN.node[*].Communication.Routing.f_measure_w_rreq = true
 SN.node[*].Communication.Routing.f_meas_rreq_count = 5 # ${RRC=1,2,5,10}
 
-SN.node[*].Communication.Routing.t_meas = 4
+#SN.node[*].Communication.Routing.t_meas = 4
 
 
 #SN.node[*].Communication.RoutingProtocolName = "flooding"

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -222,6 +222,7 @@ class shmrp: public VirtualRouting {
         bool isRreqTableEmpty() const;
         void constructRreqTable();
         bool rreqEntryExists(const char *, int);
+        int  getRreqPktCount();
         void updateRreqTableWithRresp(const char *, int);
         bool rrespReceived() const;
 


### PR DESCRIPTION
Now, in case of measure_w_rreq the T_ESTABLISH timer restarted after every sendRReqs() call.

	modified:   Simulations/shmrp/omnetpp.ini
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h