### PR TITLE
bugfix: Return to learning state if no route available (due to QoS PD…

### DIFF
--- a/Simulations/shmrp/omnetpp.ini
+++ b/Simulations/shmrp/omnetpp.ini
@@ -110,6 +110,7 @@ SN.node[*].Communication.Routing.f_cf_after_rresp = true
 SN.node[*].Communication.Routing.f_measure_w_rreq = true
 SN.node[*].Communication.Routing.f_meas_rreq_count = 10 # ${RRC=1,2,5,10}
 SN.node[*].Communication.Routing.f_calc_max_hop = true
+#SN.node[*].Communication.Routing.f_qos_pdr = 0.3
 
 #SN.node[*].Communication.Routing.t_meas = 4
 

--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -658,7 +658,7 @@ void shmrp::constructRoutingTable(bool rresp_req, bool app_cf, double pdr=0.0) {
         rinv_table[c_ne.nw_address].used=true;
     }
     if(routing_table.empty()) {
-        throw routing_table_empty("[error] routing table empty after constructRreqTable()");
+        throw routing_table_empty("[error] routing table empty after constructRoutingTable()");
     }
 }
 
@@ -839,6 +839,9 @@ void shmrp::timerFiredCallback(int index) {
                 setHop(calculateHopFromRoutingTable());
             } catch (routing_table_empty &e) {
                 trace()<<e.what();
+                trace()<<"[info] Returning to LEARN state";
+                setState(shmrpStateDef::LEARN);
+                setTimer(shmrpTimerDef::T_L,getTl());
                 break;
                 // return
             }


### PR DESCRIPTION
…R limit)

 Changes to be committed:
	modified:   Simulations/shmrp/omnetpp.ini
	modified:   src/node/communication/routing/shmrp/shmrp.cc