### PR TITLE
Serialize event and report stats from ForestFire application

### DIFF
--- a/src/node/application/ForestFire/forest_fire.h
+++ b/src/node/application/ForestFire/forest_fire.h
@@ -12,6 +12,7 @@
 
 #include "node/application/VirtualApplication.h"
 #include "node/application/ForestFire/forest_fire_packet_m.h"
+#include <yaml-cpp/yaml.h>
 
 #define REPORT_PACKET_NAME "Wildfire report"
 #define EVENT_PACKET_NAME  "Wildfire event"

--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -1189,6 +1189,8 @@ void shmrp::finishSpecific() {
         y_out<<YAML::Key<<"role";
         y_out<<YAML::Value;
         y_out<<ringToStr(getRingStatus());
+        y_out<<YAML::Key<<"pong_table";
+        y_out<<YAML::Value<<getPongTableSize();
         y_out<<YAML::Key<<"radio";
         y_out<<YAML::Value;
         serializeRadioStats(radio->getStats());
@@ -1280,6 +1282,8 @@ void shmrp::finishSpecific() {
             y_out<<"role";
             y_out<<YAML::Value;
             y_out<<(res_mgr->isDead()?"dead":ringToStr(shmrp_instance->getRingStatus()));
+            y_out<<YAML::Key<<"pong_table";
+            y_out<<YAML::Value<<shmrp_instance->getPongTableSize();
             y_out<<YAML::Key;
             y_out<<"hop";
             y_out<<YAML::Value;

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -195,7 +195,6 @@ class shmrp: public VirtualRouting {
         void sendPing(int);
         void sendPong(int);
         void storePong(shmrpPongPacket *);
-        int getPongTableSize() const;
         void clearPongTable();
         void clearPongTable(int);
 
@@ -269,6 +268,7 @@ class shmrp: public VirtualRouting {
         shmrpStateDef getState() const;
         int getHop() const;
 
+        int getPongTableSize() const;
 
         std::map<std::string,node_entry> getRoutingTable() {
             if(routing_table.empty()) {


### PR DESCRIPTION
Serialize pong table size (aka interference) to node properties

 Changes to be committed:
	modified:   src/node/application/ForestFire/forest_fire.cc
	modified:   src/node/application/ForestFire/forest_fire.h
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h