### PR TITLE
New coefficients to control pdr and hop count

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -33,8 +33,10 @@ void shmrp::startup() {
     fp.rst_learn        = par("f_restart_learning");
     fp.replay_rinv      = par("f_replay_rinv");
     fp.cost_func        = strToCostFunc(par("f_cost_function").stringValue());
-    fp.cost_func_alpha  = par("f_cost_func_alpha");
-    fp.cost_func_beta   = par("f_cost_func_beta");
+    fp.cost_func_epsilon= par("f_cost_func_epsion");
+    fp.cost_func_iota   = par("f_cost_func_iota");
+    fp.cost_func_pi     = par("f_cost_func_pi");
+    fp.cost_func_phi    = par("f_cost_func_phi");
     fp.cf_after_rresp   = par("f_cf_after_rresp");
     fp.random_t_l       = par("f_random_t_l");
     fp.random_t_l_sigma = par("f_random_t_l_sigma");
@@ -365,27 +367,27 @@ double shmrp::calculateCostFunction(node_entry ne) {
     double ret_val;
     switch (fp.cost_func) {
         case shmrpCostFuncDef::HOP: {
-            ret_val=static_cast<double>(ne.hop);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi);
             break;
         }
         case shmrpCostFuncDef::HOP_AND_PDR: {
-            ret_val=static_cast<double>(ne.hop)*static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi) * pow(static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count),fp.cost_func_phi);
             break;
         }
         case shmrpCostFuncDef::HOP_AND_INTERF: {
-            ret_val=static_cast<double>(ne.hop) * pow(ne.interf,fp.cost_func_beta);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi) * pow(ne.interf,fp.cost_func_iota);
             break;
         }
         case shmrpCostFuncDef::HOP_PDR_AND_INTERF: {
-            ret_val=static_cast<double>(ne.hop) * pow(ne.interf,fp.cost_func_beta)*static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi) * pow(ne.interf,fp.cost_func_iota) * pow(static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count),fp.cost_func_phi);
             break;
         }
         case shmrpCostFuncDef::HOP_EMERG_AND_INTERF: {
-            ret_val=static_cast<double>(ne.hop) * pow(ne.emerg,fp.cost_func_alpha) * pow(ne.interf,fp.cost_func_beta);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi) * pow(ne.emerg,fp.cost_func_epsilon) * pow(ne.interf,fp.cost_func_iota);
             break;
         }
         case shmrpCostFuncDef::HOP_EMERG_PDR_AND_INTERF: {
-            ret_val=static_cast<double>(ne.hop) * pow(ne.emerg,fp.cost_func_alpha) * pow(ne.interf,fp.cost_func_beta)*static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count);
+            ret_val=pow(static_cast<double>(ne.hop),fp.cost_func_pi) * pow(ne.emerg,fp.cost_func_epsilon) * pow(ne.interf,fp.cost_func_iota) * pow(static_cast<double>(ne.pkt_count)/static_cast<double>(ne.ack_count),fp.cost_func_phi);
             break;
         }
         default: {

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -143,8 +143,10 @@ struct feat_par {
         bool   rst_learn;
         bool   replay_rinv;
         shmrpCostFuncDef cost_func;
-        double cost_func_alpha;
-        double cost_func_beta;
+        double cost_func_epsilon;
+        double cost_func_iota;
+        double cost_func_pi;
+        double cost_func_phi;
         bool   cf_after_rresp;
         bool   random_t_l;
         double random_t_l_sigma;

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -48,8 +48,10 @@ simple shmrp like node.communication.routing.iRouting
     bool   f_restart_learning = default(false); // Restart learning if isolated
     bool   f_replay_rinv      = default(false); // Ask neighbours to re-send RINVs within round
     string f_cost_function    = default("hop"); // Cost Functions, available: hop, hop_and_interf, hop_emerg_and_interf, hop_and_pdr, hop_pdr_and_interf, hop_emerg_pdr_and_interf
-    double f_cost_func_alpha  = default(1.0);   // Alpha coeff. in cost function,  controls emerg term
-    double f_cost_func_beta   = default(1.0);   // Beta coeff. in cost function, controls interference term
+    double f_cost_func_epsilon= default(1.0);   // Alpha coeff. in cost function,  controls emerg term
+    double f_cost_func_iota   = default(1.0);   // Beta coeff. in cost function, controls interference term
+    double f_cost_func_pi     = default(1.0);   // Pi coeff. in cost function, controls pdr term
+    double f_cost_func_phi    = default(1.0);   // Phi coeff. in cost function, controls hop term
     bool   f_cf_after_rresp   = default(false); // Apply cost function based selection after RREQ/RRESP
 
     bool   f_random_t_l       = default(false); // Randomize Tl timer


### PR DESCRIPTION
Rename coefficients in cost function:
- alpha->epsilon (controls emergency)
- beta->iota (controls interference)

New coefficients:
- phi (controls hop)
- pi (controls measured pdr)

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.ned