### PR TITLE
sendRinvBasedOnHop, sendRinv methods are extended with argument local…

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -203,9 +203,9 @@ class shmrp: public VirtualRouting {
         void clearPongTable();
         void clearPongTable(int);
 
-        void sendRinv(int);
-        void sendRinv(int,int);
-        void sendRinvBasedOnHop(); 
+        void sendRinv(int,bool);
+        void sendRinv(int,int,bool);
+        void sendRinvBasedOnHop(bool); 
 
         void setHop(int);
         int calculateHop(bool);

--- a/src/node/communication/routing/shmrp/shmrp.msg
+++ b/src/node/communication/routing/shmrp/shmrp.msg
@@ -44,6 +44,7 @@ packet shmrpRinvPacket extends shmrpPacket {
     int hop;        // 2 byte
     int interf;     // 1 byte
     int emerg;      // 1 byte
+    bool local;     // 1 byte
 }
 
 packet shmrpRwarnPacket extends shmrpPacket {


### PR DESCRIPTION
…, that signals a boolean local flag in RINV message. The field is planned to used in case of local updates.

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.msg