### PR TITLE
Emergency state handling

### DIFF
--- a/src/node/application/throughputTest/ThroughputTest.cc
+++ b/src/node/application/throughputTest/ThroughputTest.cc
@@ -224,7 +224,15 @@ void ThroughputTest::finishSpecific() {
 
                 // write yaml
                 if(isSink) {
-                    y_out<<YAML::Key<<i<<YAML::Value<<rate;
+                    //y_out<<YAML::Key<<i<<YAML::Value<<rate;
+                    y_out<<YAML::Key<<i;
+                    y_out<<YAML::Value;
+                    y_out<<YAML::BeginMap;
+                    y_out<<YAML::Key<<"pkt_recv";
+                    y_out<<YAML::Value<<packetsReceived[i];
+                    y_out<<YAML::Key<<"pkt_sent";
+                    y_out<<YAML::Value<<packetsSent;
+                    y_out<<YAML::EndMap;
                 }
 
 			} else {

--- a/src/node/communication/routing/shmrp/shmrp.msg
+++ b/src/node/communication/routing/shmrp/shmrp.msg
@@ -39,12 +39,13 @@ packet shmrpPacket extends RoutingPacket {
 }
 
 packet shmrpRinvPacket extends shmrpPacket {
-    int round;      // 2 byte
-    int pathid;     // 1 byte
-    int hop;        // 2 byte
-    int interf;     // 1 byte
-    int emerg;      // 1 byte
-    bool local;     // 1 byte
+    int  round;      // 2 byte
+    int  pathid;     // 1 byte
+    int  hop;        // 2 byte
+    int  interf;     // 1 byte
+    int  emerg;      // 1 byte
+    bool local;      // 1 byte
+    int  localid;    // 1 byte
 }
 
 packet shmrpRwarnPacket extends shmrpPacket {

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -66,6 +66,7 @@ simple shmrp like node.communication.routing.iRouting
     bool   f_calc_max_hop     = default(false); // Calculate maximum possible hop
     double f_qos_pdr          = default(0.0);   // Apply QoS limit to measured PDR
     string f_routing_file     = default("routes.yaml"); // YAMl file describing static routing
+    string f_loc_rt_strat     = default("rreq_tbl"); // Routing table construction stategy during local update: rreq_table (based on rreq_table), rreq
 
     int t_rreq = default (10); // Trreq timer, default 10 sec
         double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ


### PR DESCRIPTION
Handle RWARN message sent by nodes (recalculate routing table) Some artefacts for proactive local learn
Only emit message counts from ThroughputTest application Minor bugfix wrt ack/pkt stat in routing layer

 Changes to be committed:
	modified:   src/node/application/throughputTest/ThroughputTest.cc
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.msg
	modified:   src/node/communication/routing/shmrp/shmrp.ned