### PR TITLE
New parameter: f_rt_recalc_w_emerg

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -161,6 +161,7 @@ struct feat_par {
         int    meas_rreq_count;
         bool   calc_max_hop;
         double qos_pdr;
+        bool   rt_recalc_w_emerg;
 };
 
 class shmrp: public VirtualRouting {

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -67,6 +67,7 @@ simple shmrp like node.communication.routing.iRouting
     double f_qos_pdr          = default(0.0);   // Apply QoS limit to measured PDR
     string f_routing_file     = default("routes.yaml"); // YAMl file describing static routing
     string f_loc_rt_strat     = default("rreq_tbl"); // Routing table construction stategy during local update: rreq_table (based on rreq_table), rreq
+    bool   f_rt_recalc_w_emerg= default(false); // Recalculate routing table with emergency parameter, in case of WARN message
 
     int t_rreq = default (10); // Trreq timer, default 10 sec
         double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ


### PR DESCRIPTION
Controls the node to react to WARN message with routing table recalculation
 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.ned