### PR TITLE
Second learn

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -123,6 +123,12 @@ enum shmrpRinvTblAdminDef {
             explicit no_available_entry(const char   *what_arg) : std::runtime_error(what_arg) {};
     };
 
+    class state_not_permitted : public std::runtime_error {
+        public:
+            explicit state_not_permitted(const string &what_arg) : std::runtime_error(what_arg) {};
+            explicit state_not_permitted(const char   *what_arg) : std::runtime_error(what_arg) {};
+    };
+
 //}
 
 struct node_entry {
@@ -256,7 +262,7 @@ class shmrp: public VirtualRouting {
 
         void clearRoutingTable();
         void constructRoutingTable(bool);
-        void constructRoutingTable(bool,bool,double);
+        void constructRoutingTable(bool,bool,double,bool);
         void constructRoutingTableFromRinvTable();
         void addRoute(std::string, int);
         bool isRoutingTableEmpty() const;


### PR DESCRIPTION
Introducing second learn functionality. Controlled by f_second_learn boolean parameter. After successful RRESP/RREQ/RRESP, the sink starts a second learn round that's purpose is to learn an additional path for every node. There is no mechanism to advertise the learnt path any further, it serves only local redundancy purposes.

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h