### PR TITLE
Bugfixes, tweaks and a new message IE

### DIFF
--- a/Simulations/shmrp_qos/omnetpp.ini
+++ b/Simulations/shmrp_qos/omnetpp.ini
@@ -18,7 +18,7 @@
 include ../Parameters/Castalia.ini
 
 
-sim-time-limit = 20min #2h #20min
+sim-time-limit = 30min #2h #20min
 #sim-time-limit = 3min
 
 #seed-set = ${runnumber}
@@ -115,10 +115,14 @@ SN.node[*].Communication.Routing.f_calc_max_hop = true
 SN.node[*].Communication.Routing.f_qos_pdr = 0.9
 #SN.node[*].Communication.Routing.t_meas = 4
 SN.node[*].Communication.Routing.f_rt_recalc_w_emerg = true 
-SN.node[*].Communication.Routing.f_rt_reroute_pkt = true 
+SN.node[*].Communication.Routing.f_reroute_pkt = true 
 SN.node[*].Communication.Routing.f_second_learn = "unicast"
 SN.node[*].Communication.Routing.f_t_sec_l = 2
 SN.node[*].Communication.Routing.f_t_sec_l_start = 500
+SN.node[*].Communication.Routing.f_detect_link_fail = true
+SN.node[*].Communication.Routing.f_fail_count = 30
+
+
 #SN.node[*].Communication.RoutingProtocolName = "flooding"
 #SN.node[*].Communication.RoutingProtocolName = "MultipathRingsRouting"
 #SN.node[*].Communication.Routing.repeat = ${repeat=1,2,3,4,5}
@@ -145,7 +149,7 @@ SN.physicalProcess[*].w_a = 0
 
 SN.physicalProcess[*].ca_step_period = 120
 SN.physicalProcess[*].seed = 10
-SN.physicalProcess[*].ca_start_timer = 60000
+SN.physicalProcess[*].ca_start_timer = 600
 
 
 

--- a/src/node/communication/routing/shmrp/shmrp.msg
+++ b/src/node/communication/routing/shmrp/shmrp.msg
@@ -86,6 +86,7 @@ packet shmrpLrespPacket extends shmrpPacket {
 packet shmrpDataPacket extends shmrpPacket {
     int pathid;
     int hop;
+    int reroute;
 }
 
 packet shmrpPingPacket extends shmrpPacket {


### PR DESCRIPTION
Bugfix:
- When saveRreqTable, save RREQ table RLy
- When checking link failure use correct relation...

Tweaks:
- When merging backup and new RREQ table, ovveride with existing record
  - It should be noted, that it is possible that the non-used RREQ entries re-appear during second-learn
- Trigger Route removal only if not sink-neighbor and second-learn already done
- Compensate link fail counter by expected qos pdr

New message IE:
- Indicate re-routing in DATA packets

 Changes to be committed:
	modified:   Simulations/shmrp_qos/omnetpp.ini
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.msg