### PR TITLE
New parameter in resourceManager: selfDestructTimer

### DIFF
--- a/src/node/resourceManager/ResourceManager.cc
+++ b/src/node/resourceManager/ResourceManager.cc
@@ -35,6 +35,11 @@ void ResourceManager::initialize()
 	ramSize = par("ramSize");
 	baselineNodePower = par("baselineNodePower");
 	periodicEnergyCalculationInterval = (double)par("periodicEnergyCalculationInterval") / 1000;
+    selfDestructTimer = par("selfDestructTimer");
+
+    if(selfDestructTimer > 0.0) {
+        scheduleAt(simTime() + selfDestructTimer, new cMessage("Destroy node message", DESTROY_NODE));
+    }
 
 	if (baselineNodePower < 0 || periodicEnergyCalculationInterval < 0)
 		throw cRuntimeError("Illegal values for baselineNodePower and/or periodicEnergyCalculationInterval in resource manager module");
@@ -106,6 +111,12 @@ void ResourceManager::handleMessage(cMessage * msg)
 
         case TERMINAL_EVENT: {
             trace()<<"Terminal event message received, Node terminating.";
+            destroyNode();
+            break;
+        }
+
+        case DESTROY_NODE: {
+            trace()<<"selfDestructTimer expired";
             destroyNode();
             break;
         }

--- a/src/node/resourceManager/ResourceManager.h
+++ b/src/node/resourceManager/ResourceManager.h
@@ -36,6 +36,7 @@ class ResourceManager: public CastaliaModule {
 	double currentNodePower;
 	simtime_t timeOfLastCalculation;
 	double periodicEnergyCalculationInterval;
+    double selfDestructTimer;
 
 	/*--- Custom class parameters ---*/
 	double remainingEnergy;

--- a/src/node/resourceManager/ResourceManager.ned
+++ b/src/node/resourceManager/ResourceManager.ned
@@ -33,6 +33,7 @@ simple ResourceManager {
 
 	double baselineNodePower = default (6);	// the baseline/minimum power consumption in mWatts
 	double periodicEnergyCalculationInterval = default (1000);	// maximum interval for periodic energy calculation, in msec     
+    double selfDestructTimer = default(0.0);
 
  gates:
 	output toSensorDevManager;


### PR DESCRIPTION
Node stops after expiration if selfDestructTimer.
Values: ==0.0 - not active
         >0.0 - active (second)

 Changes to be committed:
	modified:   src/node/resourceManager/ResourceManager.cc
	modified:   src/node/resourceManager/ResourceManager.h
	modified:   src/node/resourceManager/ResourceManager.ned