### PR TITLE
New feature: e2e QoS-aware pkt repeat

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.msg
+++ b/src/node/communication/routing/shmrp/shmrp.msg
@@ -87,6 +87,7 @@ packet shmrpDataPacket extends shmrpPacket {
     int pathid;
     int hop;
     int reroute;
+    int repeat;
 }
 
 packet shmrpPingPacket extends shmrpPacket {

--- a/src/node/communication/routing/shmrp/shmrp.ned
+++ b/src/node/communication/routing/shmrp/shmrp.ned
@@ -78,6 +78,10 @@ simple shmrp like node.communication.routing.iRouting
     bool   f_detect_link_fail = default(false); // Detect failing links
     int    f_fail_count       = default(10);    // Declare a link failing after f_fail_count fail msgs.
     int    f_path_sel         = default(0);     // How to select path (initially): 0 - random, 1 - only primary - 2 - prefer second
+    double f_e2e_qos_pdr      = default(0.0);   // Defines the e2e QoS PDR that has to be met. Based on the value,
+                                                // the link's hop number and the link-level QoS PDR a packet
+                                                // repetition count is identified.
+    double f_t_send_pkt       = default(1);     // Timer to repeatedly send scheduled packets to meet e2e QoS PDR
 
     int t_rreq = default (10); // Trreq timer, default 10 sec
         double min_rreq_rssi = default(-100.0); // Minimum RSSI to accept a (S)RREQ


### PR DESCRIPTION
New parameters:
o f_e2e_qos_pdr - defines the desired e2e QoS PDR
o f_t_send_pkt  - timer to send scheduled pkts periodically

The feature calculates minimum number of pkt send repeats from originating node based on the following parameters:
- hop count of node via choosen path - h
- assumed PDR of the link (= f_qos_pdr) - p_link
- e2e desired PDR - p_e2e

The number of repeats is calculated according to the formula:

R = ceil[ log(1 - p_e2e) / log(1 - p_link^h)]

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h
	modified:   src/node/communication/routing/shmrp/shmrp.msg
	modified:   src/node/communication/routing/shmrp/shmrp.ned