### PR TITLE
Bugfix: Traffic table not retrieved during serialization from node.

### DIFF
--- a/Simulations/shmrp_qos/omnetpp.ini
+++ b/Simulations/shmrp_qos/omnetpp.ini
@@ -59,7 +59,7 @@ SN.node[*].Communication.Radio.TxOutputPower = "0dBm"
 #SN.node[*].Communication.Routing.maxNetFrameSize = 200
 #SN.node[*].Communication.MAC.macMaxPacketSize = 200
 #SN.node[*].Communication.Radio.maxPhyFrameSize = 200
-SN.node[*].Communication.MAC.macBufferSize = 128
+SN.node[*].Communication.MAC.macBufferSize = 256
 
 # Throughput test application is used to send 2000-byte
 # packets to node 0 (which by default is the receiving 
@@ -68,7 +68,7 @@ SN.node[*].ApplicationName = "ThroughputTest"
 #SN.node[*].ApplicationName = "ForestFire"
 
 #SN.node[*].Application.packet_rate = ${rate=0.05,0.1,0.2,0.5,1,2}
-SN.node[*].Application.packet_rate = 0.5
+SN.node[*].Application.packet_rate = 0.1
 SN.node[*].Application.startupDelay = 130 
 
 SN.node[0].Application.isSink = true
@@ -93,7 +93,10 @@ SN.node[*].Communication.MAC.collisionResolution = 1 # ${CA=0,1,2}
 #SN.node[*].Communication.MAC.maxTxRetries = 2  # ${maxTxRetries=1,2,3,4,5,6,7,8,9,10,11}
 #SN.node[*].Communication.MAC.allowSinkSync = false
 #SN.node[*].ResourceManager.sigmaCPUClockDrift = 0.00003
-#SN.node[*].Communication.Routing.f_e2e_qos_pdr = 0.7 # 0.5
+SN.node[*].Communication.Routing.f_e2e_qos_pdr = 0.7 # 0.5
+SN.node[*].Communication.Routing.f_rep_m_pdr = true
+SN.node[*].Communication.Routing.f_t_send_pkt = 2
+
 
 SN.node[*].Communication.RoutingProtocolName = "shmrp"
 SN.node[*].Communication.Routing.f_rresp_required = true
@@ -131,6 +134,8 @@ SN.node[*].Communication.Routing.f_fail_count = 30
 #SN.node[*].Communication.Routing.repeat = 1
 #SN.node[*].Application.collectTraceInfo = true
 SN.node[0].Application.periodic_measurement = true
+#SN.node[0].Application.meas_period = true
+SN.node[*].Application.meas_queue_length = 1000
 
 
 #SN.node[*].Communication.MAC.collectTraceInfo = true

--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -2214,7 +2214,7 @@ void shmrp::finishSpecific() {
             y_out<<YAML::Key<<"traffic_table";
             y_out<<YAML::Value;
             y_out<<YAML::BeginSeq;
-            for(auto ne: traffic_table) {
+            for(auto ne: shmrp_instance->getTrafficTable()) {
                 y_out<<YAML::BeginMap;
                 y_out<<YAML::Key<<"node";
                 y_out<<YAML::Value<<ne.first;

--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -396,6 +396,9 @@ class shmrp: public VirtualRouting {
             }
             return rinv_table;
         };
+        std::map<std::string,int> getTrafficTable() {
+            return traffic_table;
+        }
 };
 
 #endif // _SHMRP_H_


### PR DESCRIPTION
 Changes to be committed:
	modified:   Simulations/shmrp_qos/omnetpp.ini
	modified:   src/node/communication/routing/shmrp/shmrp.cc
	modified:   src/node/communication/routing/shmrp/shmrp.h