### PR TITLE
Bugfix: send RWARN message if re-route fails, always

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.cc
+++ b/src/node/communication/routing/shmrp/shmrp.cc
@@ -2027,6 +2027,10 @@ void shmrp::fromMacLayer(cPacket * pkt, int srcMacAddress, double rssi, double l
                             reroute=true;
                         } catch (no_available_entry &e) {
                             trace()<<"[error] "<<e.what();
+                            if(fp.send_pfail_rwarn) {
+                                sendRwarn(shmrpWarnDef::PATH_FAILURE_EVENT,data_pkt->getPathid());
+                            }
+
                             break;
                         } catch (routing_table_empty &e) {
                             trace()<<"[error] "<<e.what();


### PR DESCRIPTION
Try to inform sender that this pathid is not working at all, maybe previous RWARN was not received

 Changes to be committed:
	modified:   src/node/communication/routing/shmrp/shmrp.cc