### PR TITLE
Feature change: Failure handling

### DIFF
--- a/src/node/communication/routing/shmrp/shmrp.h
+++ b/src/node/communication/routing/shmrp/shmrp.h
@@ -298,6 +298,7 @@ class shmrp: public VirtualRouting {
         void saveRreqTable();
         void retrieveRreqTable();
         void retrieveAndMergeRreqTable();
+        void mergePathids(std::vector<pathid_entry>&, std::vector<pathid_entry>&);
         bool isRreqTableEmpty() const;
         void constructRreqTable();
         void constructRreqTable(std::vector<int>);
@@ -356,6 +357,7 @@ class shmrp: public VirtualRouting {
         void sendRwarn();
         void sendRwarn(shmrpWarnDef, int);
 
+        void handleLinkFailure(int);
 
         void serializeRoutingTable();
         void serializeRoutingTable(std::map<std::string,node_entry>);


### PR DESCRIPTION
If link failure encountered based on:
o Fail pkt count
o Explicit RWARN with path failure
o Detected loop
The corresponding node entry is removed from:
o routing table
o RREQ table

Marked faulty in:
o RINV table

And constructRoutingTable is performed.

If the construction results in empty routing table, RWARN message is sent.